### PR TITLE
avoid need for Images.meanfinite

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,10 +7,8 @@ version = "0.3.0"
 ArgCheck = "dce04be8-c92d-5529-be00-80e4d2c0e197"
 AxisArrays = "39de3d68-74b9-583c-8d2d-e117c070f3a9"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
-Images = "916415d5-f1e6-5110-898d-aaa5f9f070e0"
 
 [compat]
 ArgCheck = "1, 2.0"
 AxisArrays = "0.3, 0.4"
-Images = "0.18, 0.19, 0.20, 0.21, 0.22"
 julia = "1"

--- a/src/ClimateBase.jl
+++ b/src/ClimateBase.jl
@@ -2,7 +2,6 @@ module ClimateBase
 
 using AxisArrays
 using ArgCheck
-using Images
 using Dates
 
 # TYPES

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -1,3 +1,12 @@
+
+"""
+    finitemean(x,y)
+
+Calculate mean while omitting NaN, Inf, etc.
+"""
+finitemean(x) = mean(filter(x -> !isnan(x)&isfinite(x),x))
+finitemean(x,y) = mapslices(finitemean,x,dims=y)
+
 """
     periodmean(C::ClimGrid; startdate::Tuple, enddate::Tuple)
 
@@ -18,13 +27,13 @@ function periodmean(C::ClimGrid; start_date::Tuple=(Inf, ), end_date::Tuple=(Inf
         if size(datain, 3) == 1 # already an average on single value
             dataout = dropdims(datain, dims=3)
         else
-            dataout = dropdims(Images.meanfinite(datain, 3), dims=3)
+            dataout = dropdims(finitemean(datain, 3), dims=3)
         end
     elseif ndims(datain) == 4
         if size(datain, 4) == 1
             dataout = dropdims(datain[:, :, :, :], dims = 3)
         else
-            dataout = dropdims(Images.meanfinite(datain, 4), dims=4)
+            dataout = dropdims(finitemean(datain, 4), dims=4)
         end
     end
 
@@ -51,7 +60,7 @@ function verticalmean(C::ClimGrid)
     if size(datain, 3) == 1 # Only one vertical level
         dataout = dropdims(datain[:, :, :, :], dims = 3)
     else
-        dataout = dropdims(Images.meanfinite(datain, 3), dims=3)
+        dataout = dropdims(finitemean(datain, 3), dims=3)
     end
 
     # Build output AxisArray


### PR DESCRIPTION
Define `finitemean` and use it in place of `Images.meanfinite` to avoid including `Images.jl` in dependencies just for `meanfinite`

ps. or maybe there is another reason to include `Images.jl` as a dependency?