### PR TITLE
Allow all temporal samplings

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -82,8 +82,8 @@ monthlyagg
 yearlyagg
 temporalrange
 maxyearspan
-monthspan
 temporal_sampling
+time_in_days
 ```
 
 ## Spatial

--- a/src/physical_dimensions/spatial.jl
+++ b/src/physical_dimensions/spatial.jl
@@ -141,7 +141,7 @@ end
 # used only with the `sum` function (for A)
 _latweights(A::AbDimArray) = _latweights(dims(A, Lat))
 function _latweights(A::Lat)
-    we = cosd.(Array(A))
+    we = cosd.(A.val)
     we ./= sum(we)
     return ClimArray(we, (A,))
 end
@@ -248,7 +248,7 @@ function hemispheric_functions(::EqArea, A)
     shi, nhi = hemisphere_indices(c)
     nh = A[Coord(nhi)]
     sh = A[Coord(shi)]
-    oldc = Array(dims(sh, Coord))
+    oldc = dims(sh, Coord).val
     si = sortperm(oldc, by = x -> x[2], rev = true)
     newc = [SVector(x[1], abs(x[2])) for x in oldc[si]]
     di = dimindex(sh, Coord)
@@ -286,5 +286,5 @@ function hemispheric_means(::EqArea, A::AbDimArray)
 end
 
 latitudes(A) = latitudes(spacestructure(A), A)
-latitudes(::Grid, A) = Array(dims(A, Lat))
+latitudes(::Grid, A) = dims(A, Lat).val
 latitudes(::EqArea, A) = unique!([x[2] for x in dims(A, Coord)])

--- a/src/physical_dimensions/temporal.jl
+++ b/src/physical_dimensions/temporal.jl
@@ -95,14 +95,15 @@ time_in_days(t::AbstractArray{<:Real}) = t
     temporal_sampling(x) → symbol
 Return the temporal sampling type of `x`, which is either an array of `Date`s or
 a dimensional array (with `Time` dimension).
-For performance reasons, only the first 3 entries of the temporal information are used
-to deduce the sampling.
 
 Possible return values are:
 - `:yearly`, where all dates have the same month+day, but different year.
 - `:monthly`, where all dates have the same day, but different month.
 - `:daily`, where the temporal difference between dates are exactly 1 day.
 - `:other`, which means that `x` doesn't fall to any of the above categories.
+
+For vector input, only the first 3 entries of the temporal information are used
+to deduce the sampling (while for ranges, checking the step is enough).
 """
 temporal_sampling(A::AbDimArray) = temporal_sampling(dims(A, Time).val)
 function temporal_sampling(t::AbstractVector{<:TimeType})
@@ -124,6 +125,10 @@ function temporal_sampling(t::AbstractVector{<:TimeType})
     end
 end
 temporal_sampling(t::AbstractVector) = error("Need `<:TimeType` elements.")
+temporal_sampling(t::StepRange{<:Any,Month}) = :monthly
+temporal_sampling(t::StepRange{<:Any,Year}) = :yearly
+temporal_sampling(t::StepRange{<:Any,Day}) = :daily
+temporal_sampling(t::StepRange{<:Any,<:Any}) = :other
 
 #########################################################################
 # temporal statistics

--- a/src/physical_dimensions/temporal.jl
+++ b/src/physical_dimensions/temporal.jl
@@ -27,10 +27,13 @@ of years (12 months), assuming monthly spaced data.
     maxyearspan(A::AbDimArray) = maxyearspan(dims(A, Time))
 """
 function maxyearspan(times, tsamp = temporal_sampling(times))
-    # TODO: Make maxyearspan work with sampling
-    length(times) % 12 == 0 && return length(times)
-    m = month(times[1])
-    findlast(i -> month(times[i]) == m, 1:length(times)) - 1
+    if tsamp == :monthly ||
+        length(times) % 12 == 0 && return length(times)
+        m = month(times[1])
+        findlast(i -> month(times[i]) == m, 1:length(times)) - 1
+    else
+        error("Not implemented yet for $tsamp data")
+    end
 end
 
 
@@ -108,7 +111,7 @@ function temporal_sampling(t::AbstractVector{<:TimeType})
     # TODO: daily aspect can be improved to cover cases where first day is the 30th
     d1 = daymonth(t[2]) .- daymonth(t[1])
     d2 = daymonth(t[3]) .- daymonth(t[2])
-    samemonth = mod1(d1[2], 12) == mod1(d1[2], 12) == 0
+    samemonth = d1[2] == d1[2] == 0
     sameday = d1[1] == d2[1] == 0
     sameyear = year(t[1]) == year(t[2]) == year(t[3])
     if sameday && samemonth && !sameyear
@@ -117,7 +120,7 @@ function temporal_sampling(t::AbstractVector{<:TimeType})
         :monthly
     elseif !sameday && samemonth
         :daily
-    elseif !sameday && !samemonth && (d1[1] > 15 || d[2] > 15)
+    elseif !sameday && !samemonth && (d1[1] > 15 || d2[1] > 15)
         :daily
     else
         :other

--- a/src/physical_dimensions/temporal.jl
+++ b/src/physical_dimensions/temporal.jl
@@ -182,7 +182,7 @@ function timeagg_yearly(f, A, w)
     elseif w isa AbDimArray
         map(i -> f(view(A, i), weights(view(W, i))), otheridxs(A, Time()))
     elseif w isa Vector
-        fw = weights(W)
+        fw = weights(w)
         map(i -> f(view(A, i), fw), otheridxs(A, Time()))
     end
 end

--- a/src/physical_dimensions/temporal.jl
+++ b/src/physical_dimensions/temporal.jl
@@ -10,7 +10,8 @@ using Statistics, StatsBase
 # TODO: monthlyagg funcion
 
 using Dates
-export monthday_indices, maxyearspan, monthspan, daymonth, DAYS_IN_YEAR, monthamount
+export monthday_indices, maxyearspan, daymonth, DAYS_IN_YEAR
+
 const DAYS_IN_YEAR = 365.26
 millisecond2month(t) = Month(round(Int, t.value / 1000 / 60 / 60 / 24 / 30))
 daymonth(t) = day(t), month(t)
@@ -32,7 +33,7 @@ function maxyearspan(times, tsamp = temporal_sampling(times))
     findlast(i -> month(times[i]) == m, 1:length(times)) - 1
 end
 
-# TODO: bad name
+
 """
     monthday_indices(times, date = times[1])
 Find the indices in `times` (which is a `Vector{Date}`) at which
@@ -102,7 +103,7 @@ Possible return values are:
 - `:other`, which means either non `Date` format for the time index,
   or sampling that doesn't fall to any of the above categories.
 """
-temporal_sampling(A::AbDimArray) = temporal_sampling(Array(dims(A, Time)))
+temporal_sampling(A::AbDimArray) = temporal_sampling(dims(A, Time).val)
 function temporal_sampling(t::AbstractVector{<:TimeType})
     # TODO: daily aspect can be improved to cover cases where first day is the 30th
     d1 = daymonth(t[2]) .- daymonth(t[1])
@@ -182,7 +183,7 @@ function timeagg(f, A::AbDimArray, w = nothing)
 end
 
 function timeagg(f, a::AbDimArray{T, 1}, exw = nothing) where {T} # version with only time dimension
-    t = Array(dims(a, Time))
+    t = dims(a, Time).val
     return timeagg(f, t, a, exw)
 end
 
@@ -218,7 +219,7 @@ using the function `f`.
 By convention, the dates of the new array always have day number of `15`.
 """
 function monthlyagg(A::ClimArray, f = mean)
-    t0 = dims(A, Time) |> Array
+    t0 = dims(A, Time).val
     startdate = Date(year(t0[1]), month(t0[1]), 15)
     finaldate = Date(year(t0[end]), month(t0[end]), 16)
     t = startdate:Month(1):finaldate
@@ -233,7 +234,7 @@ using the function `f`.
 By convention, the dates of the new array always have month and day number of `1`.
 """
 function yearlyagg(A::ClimArray, f = mean)
-    t0 = dims(A, Time) |> Array
+    t0 = dims(A, Time).val
     startdate = Date(year(t0[1]), 1, 1)
     finaldate = Date(year(t0[end]), 2, 1)
     t = startdate:Year(1):finaldate

--- a/src/physical_dimensions/temporal.jl
+++ b/src/physical_dimensions/temporal.jl
@@ -67,25 +67,24 @@ function monthspan(t::TimeType)
 end
 
 
-# TODO: better description.
 """
-    daycount(t::AbstractArray{<:TimeType}, T = Float32)
+    time_in_days(t::AbstractArray{<:TimeType}, T = Float32)
 Convert a given date time array into measurement units of days:
 a real-valued array which counts time in days, always increasing.
 """
-function daycount(t::AbstractArray{<:TimeType}, T = Float32)
+function time_in_days(t::AbstractArray{<:TimeType}, T = Float32)
     ts = temporal_sampling(t)
     if ts == :monthly
         truetime = daysinmonth.(t)
         r = T.(cumsum(truetime))
     elseif ts == :yearly
-        # TODO
+        error("todo")
     elseif ts == :daily
-        # TODO
+        error("todo")
     end
     return r
 end
-daycount(t::AbstractArray{<:Real}) = t
+time_in_days(t::AbstractArray{<:Real}) = t
 
 
 export temporal_sampling

--- a/src/physical_dimensions/temporal.jl
+++ b/src/physical_dimensions/temporal.jl
@@ -20,19 +20,22 @@ maxyearspan(A::AbDimArray, tsamp = temporal_sampling(A)) =
 maxyearspan(dims(A, Time).val, tsamp)
 
 """
-    maxyearspan(t::AbstractVector) → i
-Find the maximum index `i` of `t` so that the total time covered is a multiple
-of years (12 months), assuming monthly spaced data.
+    maxyearspan(A::ClimArray) = maxyearspan(dims(A, Time))
+    maxyearspan(t::Vector{<:DateTime}) → i
+Find the maximum index `i` of `t` so that `t[1:i]` covers exact(*) multiples of years.
 
-    maxyearspan(A::AbDimArray) = maxyearspan(dims(A, Time))
+(*) For monthly spaced data this is a multiple of `12` while for daily data we find
+the largest possible multiple of `DAYS_IN_YEAR = 365.26`.
 """
 function maxyearspan(times, tsamp = temporal_sampling(times))
-    if tsamp == :monthly ||
+    if tsamp == :monthly
         length(times) % 12 == 0 && return length(times)
         m = month(times[1])
         findlast(i -> month(times[i]) == m, 1:length(times)) - 1
+    elseif tsamp == :yearly
+        return length(times)
     else
-        error("Not implemented yet for $tsamp data")
+        error("maxyearspan: not implemented yet for $tsamp data")
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,7 +7,7 @@ Time = ClimateBase.Time
 
 # Create the artificial dimensional array A that will be used in tests
 function monthly_insolation(t::TimeType, args...)
-    d = monthspan(t)
+    d = ClimateBase.monthspan(t)
     mean(insolation(τ, args...) for τ in d)
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -92,12 +92,17 @@ end
 
 @testset "Advance temporal manipulation" begin
     tdense = Date(2000, 3, 1):Day(1):Date(2020, 3, 31)
+    tyearly = Date(2000, 3, 1):Year(1):Date(2020, 3, 31)
     mdates = unique!([(year(d), month(d)) for d in tdense])
     ydates = unique!([year(d) for d in tdense])
     tranges = temporalrange(tdense, Dates.month)
     yranges = temporalrange(tdense, Dates.year)
     @test length(tranges) == length(mdates)
     @test length(yranges) == length(ydates)
+
+    @test temporal_sampling(t) == :monthly
+    @test temporal_sampling(tdense) == :daily
+    @test temporal_sampling(tyearly) == :yearly
 
     Bz = zonalmean(B)
     # Generate an array that has daily insolation
@@ -118,6 +123,7 @@ end
         @test round(Int, e) == e
     end
     @test step(dims(Cm, Time).val) == Month(1)
+    @test temporal_sampling(dims(Cm, Time).val) == :monthly
 
     for j in 1:length(tdense)
         for i in 1:length(lats)
@@ -130,6 +136,7 @@ end
         @test round(Int, e) == e
     end
     @test step(dims(Cy, Time).val) == Year(1)
+    @test temporal_sampling(dims(Cy, Time).val) == :yearly
 
 
     # Second version: test actual physics


### PR DESCRIPTION
This PR brings all possible temporal samplings and makes them work with `timeagg` function and related ones.