### PR TITLE
greatly improve daily sampling identification

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ClimateBase"
 uuid = "35604d93-0fb8-4872-9436-495b01d137e2"
 authors = ["Datseris <datseris.george@gmail.com>", "Philippe Roy <borghor@yahoo.ca>"]
-version = "0.12.3"
+version = "0.12.4"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/core/nc_io.jl
+++ b/src/core/nc_io.jl
@@ -181,15 +181,17 @@ function vector2range(x::Vector{<:Real})
         x[i]-x[i-1] ≠ dx && return x # if no constant step, return array as is
     end
     r = x[1]:dx:x[end]
-    return r == x ? r : x
+    return r == x ? r : x # final safety check to ensure equal values
 end
 
 function vector2range(t::Vector{<:Dates.AbstractTime})
     tsamp = temporal_sampling(t)
     period = tsamp2period(tsamp)
     isnothing(period) && return t
-    r = t[1]:period:t[end]
-    return r == t ? r : t
+    t1 = period == :hourly ? t[1] : Date(t[1])
+    tf = period == :hourly ? t[end] : Date(t[end])
+    r = t1:period:tf
+    return r == t ? r : t # final safety check to ensure equal values
 end
 
 vector2range(r::AbstractRange) = r


### PR DESCRIPTION
Was just testing this with MODIS data and noticed that the daily identification had some problems. Now it works very well. Furthermore I've improved loading from `.nc` files so that if the timesampling is daily or larger, the returned dimension is has elements of `Date` instead of `DateTime`, for even smaller memory footprint and faster searching.