### PR TITLE
Change time vectors

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ClimateBase"
 uuid = "35604d93-0fb8-4872-9436-495b01d137e2"
 authors = ["Datseris <datseris.george@gmail.com>", "Philippe Roy <borghor@yahoo.ca>"]
-version = "0.12.9"
+version = "0.13.0"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -159,7 +159,7 @@ seasonalyagg
 temporalrange
 maxyearspan
 temporal_sampling
-time_in_days
+realtime_days
 ```
 
 ## Spatial

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -160,6 +160,7 @@ temporalrange
 maxyearspan
 temporal_sampling
 realtime_days
+realtime_milliseconds
 ```
 
 ## Spatial

--- a/src/physical_dimensions/temporal.jl
+++ b/src/physical_dimensions/temporal.jl
@@ -2,7 +2,7 @@
 Handling of time in data as a physical quantity, and time-related data processing
 =#
 using Statistics, StatsBase
-export monthday_indices, maxyearspan, daymonth, realtime_days, time_in_milliseconds
+export monthday_indices, maxyearspan, daymonth, realtime_days, realtime_milliseconds
 export temporal_sampling
 export timemean, timeagg
 export monthlyagg, yearlyagg, temporalrange, seasonalyagg, season
@@ -164,7 +164,7 @@ representing a timeseries `x(t)`.
 As only differences matter in this form, the returned vector always starts from 0.
 The measurement unit of time here is days.
 
-For temporal sampling less than daily return `time_in_milliseconds(t) ./ (24*60*60*1000)`.
+For temporal sampling less than daily return `realtime_milliseconds(t) ./ (24*60*60*1000)`.
 
 Example:
 ```juliarepl
@@ -193,22 +193,23 @@ function realtime_days(t::AbstractArray{<:TimeType}, T = Float32)
     elseif ts == :daily
         return T.(0:length(t)-1)
     else
-        return T.(time_in_milliseconds(t) ./ 86400000)
+        return T.(realtime_milliseconds(t) ./ 86400000)
     end
 end
 realtime_days(A) = realtime_days(dims(A, Ti).val)
 
 """
-    realtime_days(t::AbstractArray{<:TimeType}, T = Float64)
-Convert a given date time array into amount of milliseconds covered by `t` in a
-cumulative manner by taking successive differences of `t` (first entry always 0 here).
+    realtime_milliseconds(t::AbstractArray{<:TimeType}, T = Float64)
+Similar with [`realtime_days`](@ref), but now the measurement unit is millisecond.
+For extra accuracy, direct differences in `t` are used.
 """
-function time_in_milliseconds(t::AbstractArray{<:TimeType}, T = Float64)
+function realtime_milliseconds(t::AbstractArray{<:TimeType}, T = Float64)
+    @assert issorted(t)
     r = cumsum([T(x.value) for x in diff(t)])
     pushfirst!(r, 0)
     return r
 end
-time_in_milliseconds(A) = time_in_milliseconds(dims(A, Ti).val)
+realtime_milliseconds(A) = realtime_milliseconds(dims(A, Ti).val)
 
 
 #########################################################################

--- a/src/tsa/continuation.jl
+++ b/src/tsa/continuation.jl
@@ -27,7 +27,7 @@ function sinusoidal_continuation(T, frequencies = [1.0, 2.0]; Tmin = -Inf, Tmax 
     lpv = Sinusoidal(E.(frequencies ./ DAYS_IN_ORBIT))
     fullT = copy(T)
     # TODO: this must be extended to a general "true time" function
-    truetime = time_in_days(dims(T, Time).val, E)
+    truetime = realtime_days(dims(T, Time).val, E)
     for i in otheridxs(T, Time)
         x = T[i...]
         any(ismissing, x) || continue # this timeseries needs no correction

--- a/src/tsa/decomposition.jl
+++ b/src/tsa/decomposition.jl
@@ -18,7 +18,7 @@ function seasonal_decomposition(A::AbDimArray, fs::Vector)
     residual = DimensionalData.basetypeof(A)(copy(Array(A)), dims(A))
 
     t = dims(A, Time).val
-    truetime = time_in_days(t, E)
+    truetime = realtime_days(t, E)
     for i in otheridxs(A, Time)
         y = Array(A[i...])
         sea, res = SignalDecomposition.decompose(truetime, y, method)
@@ -36,7 +36,7 @@ function seasonal_decomposition(A::AbDimArray{T, 1}, fs::Vector) where {T}
     residual = DimensionalData.basetypeof(A)(copy(Array(A)), dims(A))
 
     t = dims(A, Time).val
-    truetime = time_in_days(t, E)
+    truetime = realtime_days(t, E)
     y = Array(A)
     sea, res = SignalDecomposition.decompose(truetime, y, method)
     seasonal .= sea


### PR DESCRIPTION
This PR reworks a bit what I represented so far as `time_in_days`, and even renames it.

The problem is that the original name was missleading. The returned vector does not count how many days are in one month, that is just `daysinmonth.(t)`. the function returns an incremental time counter, similarly to how one would normally tackle a timeseries `x(t)`, see the examle in the docstring.

So, I renamed it to `realtime_days` and I introduced a new one, `realtime_millisecond`. Still not sure if the name is optimal. 