### PR TITLE
Better statistical weights handling

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -207,7 +207,8 @@ For example this is a typical workflow of creating an array, assigning `missing`
 ClimateBase.jl _does not_ follow this approach for two reasons: 1) it does not comply with [Julia's `missing` propagation logic](https://docs.julialang.org/en/v1/manual/missing/), 2) using proper statistical weights gives more power to the user. As you have already seen in the documentation strings of e.g. [`timeagg`](@ref), [`spaceagg`](@ref) or [`dropagg`](@ref), you can provide explicit statistical weights of various forms.
 This gives you more power, because in the case of `missing` your statistical weights can only be 0 (missing value) or 1 (non-missing value). As an example, "pixel" of your spatial grid will have ambiguous values if it is not 100% covered by ocean, and to do a _proper_ average over ocean you should instead provide weights `W` whose value is quite simply the ocean fraction of each pixel.
 
-But what if you already have an array with `missing` values and you want to do what was described in the beginning, e.g. average by skipping the missings? Do not worry, we have you covered! Use the function [`missing_weights`](@ref)!
+But what if you already have an array with `missing` values and you want to do what was described in the beginning, e.g. average by skipping the missings? Do not worry, we have you covered! Use the function [`missing_weights`](@ref)! See also [`sinusoidal_continuation`](@ref) if the missing values are only in a subset of your temporal coverage.
+
 ```@docs
 missing_weights
 missing_val

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -10,7 +10,7 @@ For example the most common dimensions are longitude, latitude and time.
 `ClimateBase` is structured to deal with these intricacies, and in addition offer several functionalities commonly used, and sought after, by climate scientists.
 It also serves as the base building block for `ClimateTools`, which offers more advanced functionalities.
 
-At the moment the focus of `ClimateBase` is **not** operating on data *on disk*. It is designed for in-memory climate data exploration and manipulation.
+At the moment the focus of `ClimateBase` is **not** on operating on data *on disk*. It is designed for in-memory climate data exploration and manipulation.
 
 ### Installation
 This package is registered and you can install it with
@@ -197,6 +197,20 @@ The physical averages of the previous section are done by taking advantage of a 
 ```@docs
 dropagg
 collapse
+```
+
+## Missing data
+When loading an array with [`ncread`](@ref), the values of the return array may contain missing values if the actual data contain missing values according to the CF-standards.
+In other packages or other programming languages these missing values are handled "internally" and e.g. in statistical operations like `mean`, the statistics explicitly skip over missing values.
+For example this is a typical workflow of creating an array, assigning `missing` to all values of an array over land, and then taking the `mean` of the array, which would be the "mean over ocean".
+
+ClimateBase.jl _does not_ follow this approach for two reasons: 1) it does not comply with [Julia's `missing` propagation logic](https://docs.julialang.org/en/v1/manual/missing/), 2) using proper statistical weights gives more power to the user. As you have already seen in the documentation strings of e.g. [`timeagg`](@ref), [`spaceagg`](@ref) or [`dropagg`](@ref), you can provide explicit statistical weights of various forms.
+This gives you more power, because in the case of `missing` your statistical weights can only be 0 (missing value) or 1 (non-missing value). As an example, "pixel" of your spatial grid will have ambiguous values if it is not 100% covered by ocean, and to do a _proper_ average over ocean you should instead provide weights `W` whose value is quite simply the ocean fraction of each pixel.
+
+But what if you already have an array with `missing` values and you want to do what was described in the beginning, e.g. average by skipping the missings? Do not worry, we have you covered! Use the function [`missing_weights`](@ref)!
+```@docs
+missing_weights
+missing_val
 ```
 
 ## Timeseries Analysis

--- a/src/core/aggregation.jl
+++ b/src/core/aggregation.jl
@@ -26,7 +26,7 @@ values which you want to _completely skip_ during the aggregation process.
 
 This function returns `A, nothing` if `A` has no missing elements.
 """
-function missing_weights(A::ClimArray{Union{T, Missing}}, val = missing_val(A))
+function missing_weights(A::ClimArray{Union{T, Missing}}, val = missing_val(A)) where {T}
     B = zeros(T, size(A))
     W = ones(T, size(A))
     missing_idxs = findall(ismissing, A)
@@ -61,12 +61,17 @@ end
 export dropagg, nomissing, collapse, drop
 
 """
-    dropagg(f, A, dims)
+    dropagg(f, A, d [, W])
 Apply statistics/aggregating function `f` (e.g. `sum` or `mean`) on array `A` across
-dimension(s) `dims` and drop the corresponding dimension(s) from the result
+dimension(s) `d` and drop the corresponding dimension(s) from the result
 (Julia inherently keeps singleton dimensions).
 
 If `A` is one dimensional, `dropagg` will return the single number of applying `f(A)`.
+
+Optionally you can provide statistical weights in the form of an array `W`.
+`W` must have same size as `A`. An exception is when `d` is only a single
+dimension, e.g. `d = Lat`; then `W` is also allowed to be a single vector with
+length the same as `dims(A, d)`.
 """
 function dropagg(f, A, dims)
     length(size(A)) == 1 && return f(A)
@@ -79,6 +84,27 @@ function dropagg(f, A::AbDimArray, dims)
     r = dropdims(f(A; dims = dims); dims = dims)
     DimensionalData.rebuild(r, Array(r.data))
 end
+
+dropagg(f, A::ClimArray, d, w::Nothing) = dropagg(f, A, d)
+
+# TODO: Test every single clause
+function dropagg(f, A::ClimArray, d, W)
+    odims = otherdims(A, d)
+    oidxs = otheridxs(A, d)
+    D = length(odims)
+    if D == 0 # operation output is a single number
+        return f(A, weights(W))
+    elseif size(A) == size(W)
+        r = map(i -> f(view(A, i), weights(view(W, i))), oidxs)
+    elseif length(size(W)) == 1 && length(W) == length(dims(A, d))
+        fw = weights(W)
+        r = map(i -> f(view(A, i), fw), oidxs)
+    else
+        error("Given weights `W` have invalid form.")
+    end
+    return ClimArray(r, odims; name = A.name)
+end
+
 
 """
     collapse(f, A, dim)

--- a/src/core/aggregation.jl
+++ b/src/core/aggregation.jl
@@ -30,11 +30,11 @@ function missing_weights(A::ClimArray{Union{T, Missing}}, val = missing_val(A)) 
     B = zeros(T, size(A))
     W = ones(T, size(A))
     missing_idxs = findall(ismissing, A)
-    notmissing_idxs = .!(missing_idxs)
+    notmissing_idxs = findall(!ismissing, A)
     B[missing_idxs] .= val
-    B[notmissing_idxs] .= view(A, notmissing_idxs)
+    B[notmissing_idxs] .= A.data[notmissing_idxs]
     W[missing_idxs] .= 0
-    return ClimArray(B, dims(A); name = A.name, attrib = A.Attrib),
+    return ClimArray(B, dims(A); name = A.name, attrib = A.attrib),
            ClimArray(W, dims(A); name = "weights_for_missing")
 end
 missing_weights(A::ClimArray{<:Number}, val = nothing) = A, nothing

--- a/src/physical_dimensions/spatial.jl
+++ b/src/physical_dimensions/spatial.jl
@@ -75,8 +75,7 @@ export latmean, spacemean, zonalmean, spaceagg, uniquelats
     zonalmean(A::ClimArray [, W])
 Return the zonal mean of `A`. Works for both [`LonLatGrid`](@ref) as well as
 [`UnstructuredGrid`](@ref). Optionally provide statistical weights `W`.
-These _must_ be the same `size` as `A`. Use Julia's `repeat` function if you
-only have weights along a single dimension.
+These can be the same `size` as `A` or only having the same latitude structure as `A`.
 """
 zonalmean(A::AbDimArray, W = nothing) = zonalmean(spacestructure(A), A, W)
 zonalmean(::LonLatGrid, A::AbDimArray, W) = dropagg(mean, A, Lon, W)

--- a/src/physical_dimensions/spatial.jl
+++ b/src/physical_dimensions/spatial.jl
@@ -72,11 +72,14 @@ using StatsBase
 export latmean, spacemean, zonalmean, spaceagg, uniquelats
 
 """
-    zonalmean(A::ClimArray)
-Return the zonal mean of `A`.
+    zonalmean(A::ClimArray [, W])
+Return the zonal mean of `A`. Works for both [`LonLatGrid`](@ref) as well as
+[`UnstructuredGrid`](@ref). Optionally provide statistical weights `W`.
+These _must_ be the same `size` as `A`. Use Julia's `repeat` function if you
+only have weights along a single dimension.
 """
-zonalmean(A::AbDimArray) = zonalmean(spacestructure(A), A)
-zonalmean(::LonLatGrid, A::AbDimArray) = dropagg(mean, A, Lon)
+zonalmean(A::AbDimArray, W = nothing) = zonalmean(spacestructure(A), A, W)
+zonalmean(::LonLatGrid, A::AbDimArray, W) = dropagg(mean, A, Lon, W)
 
 """
     latmean(A::ClimArray)
@@ -115,8 +118,8 @@ spacemean(A, exw=nothing) = spaceagg(mean, A, exw)
 Aggregate `A` using function `f` (e.g. `mean, std`) over all available space (i.e.
 longitude and latitude) of `A`, weighting every part of `A` by its spatial area.
 
-`W` can be extra weights, to weight each spatial point with. `W` can either be
-just a `ClimArray` with same space as `A`, or of exactly same shape as `A`.
+`W` can be extra weights, to weight each spatial point with. `W` can either be a
+`ClimArray` with same spatial information as `A`, or having exactly same dimensions as `A`.
 """
 spaceagg(f, A::AbDimArray, exw=nothing) = spaceagg(spacestructure(A), f, A, exw)
 function spaceagg(::LonLatGrid, f, A::AbDimArray, w=nothing)


### PR DESCRIPTION
Motivated by the discussion in #65 this PR improves on several fronts:

1. Introduce a new function `missing_weights`. This function returns a new array without missings, and statistical weights, and can be readily used with every other function we have. This is the way we enforce the user to "handle missings explicitly" if they want to.
2. Allows `dropagg` to use statistical weights 
3. Adds a new documentation section on missing values.
4. Allows `zonalmean` to have statistical weights
