### PR TITLE
Detect and handle non-existing dimensions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ClimateBase"
 uuid = "35604d93-0fb8-4872-9436-495b01d137e2"
 authors = ["Datseris <datseris.george@gmail.com>", "Philippe Roy <borghor@yahoo.ca>"]
-version = "0.13.3"
+version = "0.13.4"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/core/nc_io.jl
+++ b/src/core/nc_io.jl
@@ -201,8 +201,8 @@ function to_proper_dimensions(dnames)
             push!(r, COMMONNAMES[n])
         else
             @warn """
-            Dimension name "$n" not in common names. Strongly recommended to ask for
-            adding this name to COMMONNAMES on GitHub. Making generic dimension for now...
+            Dimension name "$n" not in common names.
+            Making a generic dimension named `Dim{:$n}` for now...
             """
             push!(r, Dim{Symbol(n)})
         end


### PR DESCRIPTION
This PR improves `ncread` to handle bad datasets produced by people who don't know how to make the extremely simple format of an nc dataset. These people do not understand that if a data has a named dimension `x`, then the dataset must also have a field `x` which attributes actual numbers to the dimension.

This PR takes care of these people, and automatically attributes the values `1:size(A, i)` to the `i`-th dimension, which we have detected to not have actual values in the dataset.

